### PR TITLE
Implemented material3-window-size-class

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,6 +62,8 @@ dependencies {
     implementation libs.androidx.core
     implementation libs.androidx.coreSplash
 
+    implementation libs.androidx.compose.material3WindowSizeClass
+
     implementation libs.hilt.android
     kapt libs.hilt.compiler
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
                 targetSdk  : 32,
 
                 compose    : "1.2.0-alpha08",
+                material3  : "1.0.0-alpha10",
 
                 lifecycle  : "2.5.0-beta01",
 
@@ -47,14 +48,15 @@ buildscript {
                         ],
 
                         compose   : [
-                                ui                   : "androidx.compose.ui:ui:$versions.compose",
-                                uiTooling            : "androidx.compose.ui:ui-tooling:$versions.compose",
-                                uiToolingPreview     : "androidx.compose.ui:ui-tooling-preview:$versions.compose",
-                                foundation           : "androidx.compose.foundation:foundation:$versions.compose",
-                                material3            : "androidx.compose.material3:material3:1.0.0-alpha10",
-                                materialIconsExtended: "androidx.compose.material:material-icons-extended:$versions.compose",
+                                ui                      : "androidx.compose.ui:ui:$versions.compose",
+                                uiTooling               : "androidx.compose.ui:ui-tooling:$versions.compose",
+                                uiToolingPreview        : "androidx.compose.ui:ui-tooling-preview:$versions.compose",
+                                foundation              : "androidx.compose.foundation:foundation:$versions.compose",
+                                material3               : "androidx.compose.material3:material3:$versions.material3",
+                                material3WindowSizeClass: "androidx.compose.material3:material3-window-size-class:$versions.material3",
+                                materialIconsExtended   : "androidx.compose.material:material-icons-extended:$versions.compose",
 
-                                uiTest               : "androidx.compose.ui:ui-test-junit4:$versions.compose"
+                                uiTest                  : "androidx.compose.ui:ui-test-junit4:$versions.compose"
                         ]
                 ],
 

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation libs.androidx.compose.ui
     implementation libs.androidx.compose.foundation
     implementation libs.androidx.compose.material3
+    implementation libs.androidx.compose.material3WindowSizeClass
     implementation libs.androidx.compose.materialIconsExtended
     implementation libs.androidx.compose.uiToolingPreview
     implementation libs.androidx.window

--- a/ui/src/main/java/jp/numero/dagashiapp/ui/DagashiApp.kt
+++ b/ui/src/main/java/jp/numero/dagashiapp/ui/DagashiApp.kt
@@ -3,6 +3,8 @@ package jp.numero.dagashiapp.ui
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
@@ -42,7 +44,7 @@ fun DagashiApp(windowSizeClass: WindowSizeClass) {
             DagashiNavigation(
                 navController = navController,
                 homeScreen = {
-                    if (windowSizeClass == WindowSizeClass.Expanded) {
+                    if (windowSizeClass.widthSizeClass == WindowWidthSizeClass.Expanded) {
                         MilestoneListWithDetailScreen(navController)
                     } else {
                         MilestoneListScreen(navController)

--- a/ui/src/main/java/jp/numero/dagashiapp/ui/WindowSizeClass.kt
+++ b/ui/src/main/java/jp/numero/dagashiapp/ui/WindowSizeClass.kt
@@ -1,39 +1,13 @@
 package jp.numero.dagashiapp.ui
 
 import android.app.Activity
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.toComposeRect
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.DpSize
-import androidx.compose.ui.unit.dp
-import androidx.window.layout.WindowMetricsCalculator
 
-enum class WindowSizeClass { Compact, Medium, Expanded }
-
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun Activity.rememberWindowSizeClass(): WindowSizeClass {
-    val windowSize = rememberWindowSize()
-    val windowDpSize = with(LocalDensity.current) {
-        windowSize.toDpSize()
-    }
-    return getWindowSizeClass(windowDpSize)
-}
-
-@Composable
-private fun Activity.rememberWindowSize(): Size {
-    val configuration = LocalConfiguration.current
-    val windowMetrics = remember(configuration) {
-        WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(this)
-    }
-    return windowMetrics.bounds.toComposeRect().size
-}
-
-private fun getWindowSizeClass(windowDpSize: DpSize): WindowSizeClass = when {
-    windowDpSize.width < 0.dp -> throw IllegalArgumentException("Dp value cannot be negative")
-    windowDpSize.width < 600.dp -> WindowSizeClass.Compact
-    windowDpSize.width < 840.dp -> WindowSizeClass.Medium
-    else -> WindowSizeClass.Expanded
+    return calculateWindowSizeClass(this)
 }


### PR DESCRIPTION
## Overview
- `material3-window-size-class` is new library from [compose material3-alpha10](https://developer.android.com/jetpack/androidx/releases/compose-material3#1.0.0-alpha10)
- Replace the existing implementation with `material3-window-size-class`